### PR TITLE
Add TypeSortedCollections version.

### DIFF
--- a/containers.jl
+++ b/containers.jl
@@ -187,12 +187,15 @@ mutable struct TypeSortedContainer
 end
 
 function addconstraint!(c::TypeSortedContainer, fs::Tuple{F, S}) where {F <: AbstractFunction, S <: AbstractSet}
-    if fs isa eltype(c.constraints)
-        push!(c.constraints, fs)
-    else
-        c.constraints = vcat(c.constraints, fs)
-    end
+    _addconstraint!(c, c.constraints, fs)
+    nothing
 end
+
+@noinline _addconstraint!(c::TypeSortedContainer, constraints::TypeSortedCollection, fs) = _addconstraint!(c, constraints, eltype(constraints), fs)
+@inline _addconstraint!(c::TypeSortedContainer, constraints::TypeSortedCollection, ::Type{T}, fs::FS) where {T, FS<:T} = (push!(c.constraints, fs); nothing)
+@inline _addconstraint!(c::TypeSortedContainer, ::TypeSortedCollection, ::Type, fs) = (c.constraints = vcat(c.constraints, fs); nothing)
+
+
 
 eachconstraint(f, c::TypeSortedContainer) = _eachconstraint(f, c.constraints)
 @noinline _eachconstraint(f, constraints::TypeSortedCollection) = foreach(f, constraints)


### PR DESCRIPTION
Works with the `vcat` branch of `TypeSortedCollections`.

results (with safety checks in `TypeSortedCollection` constructor disabled:
```julia
tk-sloth:jump-containers twan$ julia --color=yes --check-bounds=no -O3 containers.jl 
container = SpecializedContainer
Adding constraints: 	  2.196 μs (66 allocations: 7.69 KiB)
Iterating over constraints: 	  4.589 μs (123 allocations: 13.08 KiB)
container = TypeContainer
Adding constraints: 	  8.975 μs (70 allocations: 8.00 KiB)
Iterating over constraints: 	  4.831 μs (123 allocations: 13.08 KiB)
container = IDContainer
Adding constraints: 	  7.860 μs (70 allocations: 8.00 KiB)
Iterating over constraints: 	  4.886 μs (123 allocations: 13.08 KiB)
container = IDVectContainer
Adding constraints: 	  5.378 μs (61 allocations: 7.78 KiB)
Iterating over constraints: 	  4.760 μs (123 allocations: 13.08 KiB)
container = ErasedContainer
Adding constraints: 	  2.899 μs (154 allocations: 8.19 KiB)
Iterating over constraints: 	  15.651 μs (342 allocations: 16.52 KiB)
container = TypeSortedContainer
Adding constraints: 	  29.181 μs (299 allocations: 17.61 KiB)
Iterating over constraints: 	  5.529 μs (123 allocations: 13.08 KiB)
```